### PR TITLE
Fix to work Notification api

### DIFF
--- a/src/js/background_page.coffee
+++ b/src/js/background_page.coffee
@@ -12,11 +12,6 @@ store.add 'meta', 'version', manifest.version
 notify = do ->
   notifications = []
 
-  showNotification = ->
-    maxCount = Number(store.config['maxNotificationCount']) || 3
-    for i in [0...maxCount]
-      notifications[i]?.show()
-
   (ghEventData) ->
     ghEvent = GhEvent.createByType(ghEventData)
     notification = new Notification ghEvent.title(),
@@ -38,10 +33,8 @@ notify = do ->
     notification.onclose = ->
       if (index = notifications.indexOf(this)) >= 0
         notifications.splice(index, 1)
-      showNotification()
 
     notifications.push(notification)
-    showNotification()
 
 clearIconCache = ->
   console.log('icon cache expired')

--- a/src/options_page.haml
+++ b/src/options_page.haml
@@ -20,11 +20,6 @@
           %dd
             %input{:type => 'number', :name => 'notificationTimeout', :min => '0', 'data-default-value' => 0, 'data-template' => 'saved'}
             seconds
-          %dt
-            will be allowed to show max
-          %dd
-            %input{:type => 'number', :name => 'maxNotificationCount', :max => 3, :min => 1, 'data-default-value' => 3, 'data-template' => 'saved'}
-            counts
 
       %form.resetConfig
         %dl


### PR DESCRIPTION
Chrome >= 35 doesn't  have `webkitNotifications`.
It became W3C `Notification` API.
